### PR TITLE
feat: implement event-based case status change handling

### DIFF
--- a/audit-service/src/main/java/com/auditservice/domain/CaseStatus.java
+++ b/audit-service/src/main/java/com/auditservice/domain/CaseStatus.java
@@ -1,8 +1,11 @@
 package com.auditservice.domain;
 
 public enum CaseStatus {
+    DRAFT,
     SUBMITTED,
     IN_REVIEW,
+    DECISION_PENDING,
     APPROVED,
-    REJECTED
+    REJECTED,
+    CLOSED
 }

--- a/case-service/src/main/java/com/caseservice/configuration/CaseAmqpConfig.java
+++ b/case-service/src/main/java/com/caseservice/configuration/CaseAmqpConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 public class CaseAmqpConfig {
 
     public static final String EXCHANGE = "case.events.exchange";
-    public static final String QUEUE = "case.status.changed.queue";
     public static final String ROUTING_KEY = "case.status.changed";
 
     @Bean

--- a/case-service/src/main/java/com/caseservice/event/CaseStatusChangedEventListener.java
+++ b/case-service/src/main/java/com/caseservice/event/CaseStatusChangedEventListener.java
@@ -1,0 +1,20 @@
+package com.caseservice.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CaseStatusChangedEventListener {
+    private final CaseEventPublisher caseEventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(CaseStatusChangedEvent event) {
+        log.info("Transaction committed. Publishing event to RabbitMQ: {}", event);
+        caseEventPublisher.publishStatusChanged(event);
+    }
+}

--- a/case-service/src/main/java/com/caseservice/service/CaseService.java
+++ b/case-service/src/main/java/com/caseservice/service/CaseService.java
@@ -7,7 +7,6 @@ import com.caseservice.domain.CaseStatusTransitions;
 import com.caseservice.dto.request.CreateCaseRequest;
 import com.caseservice.dto.response.CaseEntityDto;
 import com.caseservice.dto.response.CaseResponse;
-import com.caseservice.event.CaseEventPublisher;
 import com.caseservice.event.CaseStatusChangedEvent;
 import com.caseservice.exceptions.CaseAlreadyExistsException;
 import com.caseservice.exceptions.CaseNotFoundException;
@@ -17,6 +16,7 @@ import com.caseservice.repository.CaseRepository;
 import com.caseservice.repository.CaseStatusHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +38,8 @@ public class CaseService {
 
     private final CaseStatusHistoryRepository historyRepository;
 
-    private final CaseEventPublisher caseEventPublisher;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
 
     @Transactional
     public CaseResponse createCase(CreateCaseRequest createCaseRequest) {
@@ -99,7 +100,7 @@ public class CaseService {
 
         caseEntity.setStatus(newStatus);
 
-        caseEventPublisher.publishStatusChanged(
+        applicationEventPublisher.publishEvent(
                 new CaseStatusChangedEvent(
                         caseId,
                         oldStatus,


### PR DESCRIPTION
- add CaseStatusChangedEventListener to process events post-commit
- replace direct CaseEventPublisher usage with Spring’s ApplicationEventPublisher
- update CaseStatus enum to include DRAFT, DECISION_PENDING, and CLOSED
- refactor CaseService to utilize application events for status changes
- remove unused queue configuration from CaseAmqpConfig